### PR TITLE
Handle pipelines

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -279,7 +279,8 @@ export function buildAmplifyConfig(
       .map((r) => buildResolver(r, config, servicePath))
       .filter(nonNullable),
     functions: Object.values(config.pipelineFunctions)
-      .map((f) => buildFunction(f, config, servicePath)),
+      .map((f) => buildFunction(f, config, servicePath))
+      .filter(nonNullable),
     dataSources: Object.values(config.dataSources)
       .map((d) => buildDataSource(d, service, options))
       .filter(nonNullable),
@@ -401,7 +402,7 @@ function buildFunction(
       config,
       servicePath,
     ),
-  };
+  } as unknown as AppSyncSimulatorFunctionsConfig; // Temp fix until amplify-appsync-simulator typings are fixed
 }
 
 function buildMappingTemplate(

--- a/src/config.ts
+++ b/src/config.ts
@@ -278,7 +278,8 @@ export function buildAmplifyConfig(
     resolvers: Object.values(config.resolvers)
       .map((r) => buildResolver(r, config, servicePath))
       .filter(nonNullable),
-    functions: Object.values(config.pipelineFunctions).map(buildFunction),
+    functions: Object.values(config.pipelineFunctions)
+      .map((f) => buildFunction(f, config, servicePath)),
     dataSources: Object.values(config.dataSources)
       .map((d) => buildDataSource(d, service, options))
       .filter(nonNullable),
@@ -381,13 +382,25 @@ function buildResolver(
 }
 
 function buildFunction(
-  config: DeepResolved<PipelineFunctionConfig>,
+  pipelineFunctionConfig: DeepResolved<PipelineFunctionConfig>,
+  config: Config,
+  servicePath: string,
 ): AppSyncSimulatorFunctionsConfig {
   return {
-    name: config.name,
-    dataSourceName: config.dataSource,
-    requestMappingTemplateLocation: config.request ?? '',
-    responseMappingTemplateLocation: config.response ?? '',
+    name: pipelineFunctionConfig.name,
+    dataSourceName: pipelineFunctionConfig.dataSource,
+    requestMappingTemplate: buildMappingTemplate(
+      pipelineFunctionConfig,
+      'request',
+      config,
+      servicePath,
+    ),
+    responseMappingTemplate: buildMappingTemplate(
+      pipelineFunctionConfig,
+      'response',
+      config,
+      servicePath,
+    ),
   };
 }
 


### PR DESCRIPTION
I had an issue with pipelines functions breaking using this PR.

Looking into it it was an issue with serverless-appsync-simulator not building the VTL Mapping Templates.
Here is a quick fix using `buildMappingTemplate()` which was already used to build every other mapping template used by appsync-simulator